### PR TITLE
gkeys.log: Isolate file-handler code in the logpath branch

### DIFF
--- a/gkeys/log.py
+++ b/gkeys/log.py
@@ -18,7 +18,6 @@ import os
 NAMESPACE = 'gentoo-keys'
 logger = None
 Console_handler = None
-File_handler = None
 
 log_levels = {
     'CRITICAL': logging.CRITICAL,
@@ -33,7 +32,7 @@ log_levels = {
 
 
 def set_logger(namespace=None, logpath='', level=None):
-    global logger, NAMESPACE, Console_handler, File_handler
+    global logger, NAMESPACE, Console_handler
     if not namespace:
         namespace = NAMESPACE
     else:
@@ -47,22 +46,22 @@ def set_logger(namespace=None, logpath='', level=None):
     if logpath:
         logname = os.path.join(logpath,
             '%s-%s.log' % (namespace, time.strftime('%Y%m%d-%H:%M')))
-        File_handler = logging.FileHandler(logname)
+        file_handler = logging.FileHandler(logname)
         if level:
             #print "Setting cli log level", level, log_levels[level]
-            File_handler.setLevel(log_levels[level])
+            file_handler.setLevel(log_levels[level])
         else:
             #print "Create file handler which logs even debug messages"
-            File_handler.setLevel(log_levels['DEBUG'])
+            file_handler.setLevel(log_levels['DEBUG'])
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
 
-    File_handler.setFormatter(formatter)
     # create console handler with a higher log level
     Console_handler = logging.StreamHandler()
     Console_handler.setLevel(logging.ERROR)
     #Console_handler.setFormatter(formatter)
     logger.addHandler(Console_handler)
-    logger.addHandler(File_handler)
-    #print "File logger suppose to be initialized", logger, File_handler, Console_handler
+    #print "File logger suppose to be initialized", logger, Console_handler
     logger.debug("Loggers initialized")
 
     return logger


### PR DESCRIPTION
There's no need for this variable if logpath isn't set, so remove the global
variable and external references.

Also downcase it to the more Pythonic 'file_handler'.  PEP8 doesn't even
recognize a 'Sentence_case' naming style [1](http://legacy.python.org/dev/peps/pep-0008/#descriptive-naming-styles).
