### PR TITLE
Binary keyring support

### DIFF
--- a/etc/gkeys.conf.sample
+++ b/etc/gkeys.conf.sample
@@ -20,6 +20,9 @@ dev-keydir: %(keysdir)s/devs
 # will be stored.
 rel-keydir: %(keysdir)s/release
 
+# keyring: the directory where the official keyring  with the specified keys
+# will be exported.
+keyring: %(keysdir)s/keyring
 
 # overlayskeydir: the directory where the overlay keys
 # will be stored.

--- a/gkeys/cli.py
+++ b/gkeys/cli.py
@@ -70,6 +70,8 @@ class Main(object):
             help='The logging level to set for the logfile')
         parser.add_argument('-f', '--fingerprint', dest='fingerprint', default=None,
             help='The fingerprint of the the key')
+        parser.add_argument('-k', '--keyring', dest='keyring', default='trusted_keyring',
+            help='The name of the keyring to use')
         parser.add_argument('-n', '--nick', dest='nick', default=None,
             help='The nick associated with the the key')
         parser.add_argument('-N', '--name', dest='name', nargs='*',

--- a/gkeys/config.py
+++ b/gkeys/config.py
@@ -73,6 +73,7 @@ class GKeysConfig(GPGConfig):
         self.defaults['keysdir'] = path([self.root, EPREFIX, '/var/gentoo/gkeys'])
         self.defaults['dev-keydir'] = '%(keysdir)s/devs'
         self.defaults['rel-keydir'] = '%(keysdir)s/release'
+        self.defaults['keyring'] = '%(keysdir)s/keyring'
         self.defaults['overlays-keydir'] = '%(keysdir)s/overlays'
         self.defaults['logdir'] = '%(keysdir)s/logs'
         # local directory to scan for seed files installed via ebuild, layman


### PR DESCRIPTION
Gentoo Keys can now export a public keyring with specified trusted keys.
That binary keyring can be signed by a Certificate Authority(CA) and
distributed to the users.
