### PR TITLE
Fixed a bug in the verify function

### DIFF
--- a/gkeys/gkeys/actions.py
+++ b/gkeys/gkeys/actions.py
@@ -689,7 +689,6 @@ class Actions(ActionBase):
             messages.append(_unicode("Using config defaults..: %s %s")
                 % (args.category, args.nick))
             return self.verify(args, messages)
-
         return self._verify(args, key, messages)
 
 
@@ -776,6 +775,8 @@ class Actions(ActionBase):
                         break
                     else:
                         sig_path = None
+            elif signature:
+                sig_path = os.path.abspath(signature)
         self.logger.info("Verifying file...")
         verified = False
         results = self.gpg.verify_file(key, sig_path, filepath)


### PR DESCRIPTION
The `verify` function wasn't wasn't working when given a signature because when the signature was valid, it didn't add it's path to `sig_path`, so it was running `self.gpg.verify_file(key, sig_path, filepath)` with `sig_path` being `None`, thus giving an error.

My fix basically checks if a signature has been given and if so, it gives its path to `sig_path`.

I tested for [this file](https://download.sumptuouscapital.com/gentoo/gsoc/testfile.txt) and [this signature](https://download.sumptuouscapital.com/gentoo/gsoc/testfile.txt.asc), which worked as expected after the fix.