### PR TITLE
Email reminders for expiry

### DIFF
--- a/gkeys/etc/gkeys.conf
+++ b/gkeys/etc/gkeys.conf
@@ -6,6 +6,8 @@
 # keyserver: server to use to obtain the keys from
 keyserver: pool.sks-keyservers.net
 
+#Days limit for keys nearing expiry
+#days_limit = 30
 
 # gkeysdir: Base directory to use as the path prefix to use
 # for the gkey directories, keyring settings
@@ -24,6 +26,8 @@ gkeysdir: /var/lib/gentoo/gkeys
 # user gkey directory
 user-dir = %(homedir)s/gkeys-user
 
+#Template directory
+template_path = /usr/share/gkeys/templates
 
 # base keyring dir
 keyring: %(gkeysdir)s/keyrings

--- a/gkeys/gkeys/action_map.py
+++ b/gkeys/gkeys/action_map.py
@@ -275,7 +275,7 @@ Do you really want to remove dolsen?[y/n]: y
     ('spec-check', {
         'func': 'speccheck',
         'options': ['category', 'nick', 'name', 'fingerprint', 'keyid', 'keys',
-            'keydir', 'keyring'],
+            'keydir', 'keyring', 'email', 'user'],
         'desc': '''Check if keys meet specifications requirements''',
         'long_desc': '''Check if keys meet specifications requirements''',
         'example': '''$ gkeys spec-check -C gentoo -n gkeys

--- a/gkeys/gkeys/actions.py
+++ b/gkeys/gkeys/actions.py
@@ -29,6 +29,7 @@ from collections import defaultdict
 from gkeys.actionbase import ActionBase
 from gkeys.gkey import GKEY
 from gkeys.checks import SPECCHECK_SUMMARY, convert_pf, convert_yn
+from gkeys.mail import Emailer
 
 from snakeoil.demandload import demandload
 
@@ -239,7 +240,7 @@ class Actions(ActionBase):
                 else:
                     print(_unicode("           %s") % line)
                 c += 1
-            self.logger.debug(_unicode("data output:\n") + str(result))
+            self.logger.debug(_unicode("data output:\n") + _unicode(result))
         return (True, result)
 
 
@@ -380,6 +381,17 @@ class Actions(ActionBase):
         results = {}
         failed = defaultdict(list)
         self.output('', '\n Checking keys...')
+        '''Login email'''
+        if args.email in ['expiry']:
+            if args.user:
+                email_user = self.config.get_key(args.user)
+            else:
+                email_user = self.config.get_key('login_gentoo')
+            emailer = Emailer(email_user, self.logger)
+            template_path = os.path.join(self.config.get_key('template_path'), "expiry_template")
+            message_template = self.keyhandler.set_template(template_path)
+            self.logger.debug(_unicode('Emailer started with login: %s') \
+                % _unicode(email_user['login_email']))
         for gkey in sorted(keyresults):
             self.logger.info(_unicode("Checking key %s, %s")
                 % (gkey.nick, gkey.keys))
@@ -393,9 +405,10 @@ class Actions(ActionBase):
                 results = self.gpg.speccheck(gkey.keydir, key)
                 for g in results:
                     pub_pass = {}
+                    key_print = ''
                     for key in results[g]:
                         self.output('', key.pretty_print())
-
+                        key_print += '\n\n' + key.pretty_print()
                         if key.key is "PUB":
                             pub_pass = {
                                 'key': key,
@@ -474,7 +487,25 @@ class Actions(ActionBase):
                     sdata = convert_pf(pub_pass, ['pub', 'sign', 'final'])
                     sdata = convert_yn(sdata, ['auth', 'encrypt'])
                     self.output('', SPECCHECK_SUMMARY % sdata)
-
+                    '''Email reminder code'''
+                    if args.email in ['expiry']:
+                        uid = ''
+                        if gkey.uid:
+                            uids = gkey.uid                            
+                            uid = self.keyhandler.find_email(uids, self.config.get_key('prefered_address'))
+                        self.logger.debug(_unicode('The valid uid is: %s') % uid)
+                        days_limit = int(self.config.get_key('days_limit'))
+                        self.logger.debug(_unicode('Days_limit for expiry is: %s') \
+                            % _unicode(days_limit))
+                        is_exp = self.keyhandler.is_expiring(results, days_limit)
+                        if is_exp and uid:
+                            self.logger.debug(_unicode('Process for emailing started'))
+                            message = self.keyhandler.generate_template(message_template, \
+                                key_print, SPECCHECK_SUMMARY % sdata)
+                            emailer.send_email(uid, message)
+        if args.email in ['expiry']:
+            emailer.email_quit()
+            self.logger.debug(_unicode('Emailer quit'))
         if failed['revoked']:
             self.output([sorted(set(failed['revoked']))], '\n Revoked keys:')
         if failed['invalid']:
@@ -513,7 +544,6 @@ class Actions(ActionBase):
                 '=============================',
                 'SPEC Approved..........: %d' % len(set(failed['spec-approved'])),
             ])
-
 
     def removekey(self, args):
         '''Remove an installed key'''

--- a/gkeys/gkeys/base.py
+++ b/gkeys/gkeys/base.py
@@ -222,6 +222,15 @@ class CliBase(object):
         parser.add_argument('-u', '--uid', dest='uid', nargs='+', default=None,
             help='The user ID, gpg key uid')
 
+    @staticmethod
+    def _option_email(parser=None):
+        parser.add_argument('-E', '--email', dest='email', default=None,
+            help='Email parameter for sending email reminders')
+
+    @staticmethod
+    def _option_user(parser=None):
+        parser.add_argument('-U', '--user', dest='user', default=None,
+            help='User parameter for service login')
 
     def parse_args(self, argv):
         '''Parse a list of aruments

--- a/gkeys/gkeys/base.py
+++ b/gkeys/gkeys/base.py
@@ -296,7 +296,12 @@ class CliBase(object):
             args = self.parse_args(args)
         if args.config:
             self.config.defaults['config'] = args.config
-            self.config.read_config()
+            self.config.defaults['configdir'] = os.path.dirname(args.config)
+            if args.email:
+                configs = [self.config.defaults['config'], os.path.abspath(os.path.join(self.config.defaults['configdir'], "email.conf"))]
+                self.config.read_config(configs)
+            else:
+                self.config.read_config()
         else:
             self.config.read_config(configs)
 

--- a/gkeys/gkeys/config.py
+++ b/gkeys/gkeys/config.py
@@ -59,6 +59,7 @@ class GKeysConfig(GPGConfig):
             self.defaults['configdir'] = self.defaults['userconfigdir']
             self.defaults['config']= os.path.join(
                 self.defaults['userconfigdir'], 'gkeys.conf')
+            self.defaults['template_path'] = '/usr/share/gkeys/templates'
             if not os.path.exists(self.defaults['config']):
                 self.defaults['configdir'] = path([self.root, EPREFIX, '/etc/gkeys'])
                 self.defaults['config'] = '%(configdir)s/gkeys.conf'
@@ -85,6 +86,7 @@ class GKeysConfig(GPGConfig):
         self.defaults['verify-keyring'] = 'gentoo'
         self.defaults['verify-nick'] = 'gkeys'
         self.defaults['verify-seeds'] = {}
+        self.defaults['days_limit'] = 30
 
 
     def read_config(self, filename=None):
@@ -98,7 +100,7 @@ class GKeysConfig(GPGConfig):
             self.defaults[key] = self._sub_(self.defaults[key])
         defaults = OrderedDict()
         # Add only the defaults we want in the configparser
-        for key in ['gkeysdir', 'homedir', 'keyring', 'sign-keydir', 'logdir',
+        for key in ['userconfigdir', 'gkeysdir', 'homedir', 'keyring', 'sign-keydir', 'logdir',
             'seedsdir', 'keyserver']:
             defaults[key] = self.defaults[key]
         if filename == None:
@@ -137,4 +139,3 @@ class GKeysConfig(GPGConfig):
                 return super(GKeysConfig, self)._get_(key, subkey)
         else:
             return super(GKeysConfig, self)._get_(key, subkey)
-

--- a/gkeys/gkeys/mail.py
+++ b/gkeys/gkeys/mail.py
@@ -1,0 +1,51 @@
+from __future__ import print_function
+
+import os
+import smtplib
+import sys
+import email.utils
+
+from email.mime.text import MIMEText
+from snakeoil.demandload import demandload
+
+if sys.version_info[0] >= 3:
+    py_input = input
+    _unicode = str
+else:
+    py_input = raw_input
+    _unicode = unicode
+
+demandload(
+    "gkeys.base:Args",
+    "json:load",
+)
+
+class Emailer(object):
+    '''Send an email reminder about the status of the user's GPG key'''
+
+    def __init__(self, login, logger):
+        self.logger = logger
+        self.email_from = _unicode(login['login_email'])
+        self.sender_full_name = _unicode(login['full_name'])
+        login_passwd = login['passwd']
+        server = login['server']
+        self.mail = smtplib.SMTP(server, 587)
+        self.mail.ehlo()
+        self.mail.starttls()
+        self.mail.login(self.email_from, login_passwd)
+        self.logger.debug(_unicode("Login successfull"))
+
+    def send_email(self, uid, message):
+        self.logger.debug(_unicode('Sending email with message %s') % _unicode(message))
+        subject = "Expiring Key"
+        email_to = uid
+        msg = MIMEText(message, 'plain')
+        msg['Subject'] = subject
+        msg['From'] = email.utils.formataddr((self.sender_full_name, self.email_from))
+        msg['To'] = email_to
+        self.logger.info(_unicode('Sending the email reminder from %s to %s') \
+            % (self.email_from, email_to))
+        self.mail.sendmail(self.email_from, email_to, msg.as_string())
+
+    def email_quit(self):
+        self.mail.quit()


### PR DESCRIPTION
I created a script which I integrated in `spec-check` that sends email reminders to users whose keys have expired or will expire recently. In order to do this:

I added 2 `args` parameters called `--email` and `--user` in `base.py` to be given to spec-check in order for the script to run. (The `--user` is optional for the user to select with which account to login)
I added a template_path and a commented days limit value in `gkeys.conf`.
I added a 180 default value for the days limit in `config.py`.
I added a few more lines of code in `actions.py` that if `args.email` == `expiry` it logs in to the email server using the config credentials, checks every key if they pass the days limit, finds the user's email, compiles a message that includes all necessary information and sends the message to the user's email.
I added some helper methods in `keyhandler.py` as well.
I created a new file called `mail.py` that handles the email login and the email sending.
I also added another config file called `email.conf` that includes the 2 templates for email users' credentials and a preferred address ending with the default being `@gentoo` which if enabled will only send emails to these addresses.

To test I used, `gkeys -c gkeys/etc/gkeys.conf -C gentoo-devs --email expiry --user foo` with my email credentials edited in the `email.conf` file in `foo` and my other email instead of the user's email and got the expected result which was an email which includes information, resources for help and the `Spec-Check` tuple print.
