### PR TITLE
Actions.checkkey: fix success returncode

### DIFF
--- a/gkeys/gkeys/actions.py
+++ b/gkeys/gkeys/actions.py
@@ -13,6 +13,7 @@
 
 from __future__ import print_function
 
+import itertools
 import os
 import sys
 
@@ -360,7 +361,7 @@ class Actions(ActionBase):
             self.output([failed['invalid']], '\n Invalid keys:\n')
         if failed['sign']:
             self.output([failed['sign']], '\n No signing capable subkeys:\n')
-        return (len(failed) <1,
+        return (not any(itertools.chain.from_iterable(failed.values())),
             ['\nFound:\n-------', 'Expired: %d' % len(failed['expired']),
                 'Revoked: %d' % len(failed['revoked']),
                 'Invalid: %d' % len(failed['invalid']),


### PR DESCRIPTION
The failed dictionary contains lists for each type of failure,
so return success if all of those lists are emtpy.

@dol-sen